### PR TITLE
adding TagDetector ctor with TagFamily as input

### DIFF
--- a/apriltags/include/AprilTags/TagDetector.h
+++ b/apriltags/include/AprilTags/TagDetector.h
@@ -19,6 +19,8 @@ public:
 	//! Constructor
   // note: TagFamily is instantiated here from TagCodes
 	TagDetector(const TagCodes& tagCodes) : thisTagFamily(tagCodes) {}
+
+        TagDetector(const TagFamily& tagFamily) : thisTagFamily(tagFamily) {}
 	
 	std::vector<TagDetection> extractTags(const cv::Mat& image);
 	

--- a/apriltags/include/AprilTags/TagFamily.h
+++ b/apriltags/include/AprilTags/TagFamily.h
@@ -30,6 +30,8 @@ public:
   //! The codes array is not copied internally and so must not be modified externally.
   TagFamily(const TagCodes& tagCodes);
 
+  TagFamily(const TagFamily& tagFamily);
+
   void setErrorRecoveryBits(int b);
 
   void setErrorRecoveryFraction(float v);

--- a/apriltags/src/TagFamily.cc
+++ b/apriltags/src/TagFamily.cc
@@ -35,6 +35,11 @@ TagFamily::TagFamily(const TagCodes& tagCodes)
   codes = tagCodes.codes;
 }
 
+TagFamily::TagFamily(const TagFamily& tagFamily)
+  : blackBorder(tagFamily.blackBorder), bits(tagFamily.bits), dimension(tagFamily.dimension),
+    minimumHammingDistance(tagFamily.minimumHammingDistance),
+    errorRecoveryBits(tagFamily.errorRecoveryBits), codes(tagFamily.codes) {}
+
 void TagFamily::setErrorRecoveryBits(int b) {
   errorRecoveryBits = b;
 }


### PR DESCRIPTION
thisTagFamily is const, and is only set during TagDetector construction from tag codes. The TagFamily constructor invoked from the tag codes assumes a bunch of default settings (eg, borderSize=1) that should be able to be set before creating a TagDetector object.